### PR TITLE
Rename class JModuleHelper to MVCOverrideModuleHelper to avoid collisions with other plugins and components

### DIFF
--- a/module/helper.php
+++ b/module/helper.php
@@ -9,7 +9,7 @@ defined('_JEXEC') or die;
  * @subpackage  Module
  * @since       11.1
  */
-abstract class JModuleHelper extends JModuleHelperLibraryDefault
+abstract class MVCoverrideModuleHelper extends JModuleHelperLibraryDefault
 {
 	/**
 	 * An array to hold included paths


### PR DESCRIPTION
When using T3 v3 plugin with JEvents and mvcoverride there is a class name clash which is resolvable by changing the class name from JModuleHelper to something unique, like MVCoverrideModuleHelper.